### PR TITLE
Add coin detail screen and navigation logic

### DIFF
--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailAction.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailAction.kt
@@ -1,0 +1,5 @@
+package com.johnkenedy.cryptotracker.crypto.presentation.coin_detail
+
+sealed interface CoinDetailAction {
+
+}

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailScreen.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailScreen.kt
@@ -1,0 +1,153 @@
+package com.johnkenedy.cryptotracker.crypto.presentation.coin_detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.johnkenedy.cryptotracker.R
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_detail.components.InfoCard
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.CoinListState
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.components.previewCoin
+import com.johnkenedy.cryptotracker.crypto.presentation.models.toDisplayableNumber
+import com.johnkenedy.cryptotracker.ui.theme.CryptoTrackerTheme
+import com.johnkenedy.cryptotracker.ui.theme.greenBackground
+
+@Composable
+fun CoinDetailScreenRoot(
+    viewModel: CoinDetailViewModel = viewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    CoinDetailScreen(
+        state = state,
+        onAction = viewModel::onAction
+    )
+}
+
+@Composable
+fun CoinDetailScreen(
+    state: CoinListState,
+    onAction: (CoinDetailAction) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val contentColor = if (isSystemInDarkTheme()) {
+        Color.White
+    } else Color.Black
+
+    if (state.isLoading) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    } else if (state.selectedCoin != null) {
+        val coin = state.selectedCoin
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(
+                    id = coin.iconRes
+                ),
+                contentDescription = coin.name,
+                modifier = Modifier.size(100.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = coin.name,
+                fontSize = 40.sp,
+                fontWeight = FontWeight.Black,
+                textAlign = TextAlign.Center,
+                color = contentColor
+            )
+            Text(
+                text = coin.symbol,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Light,
+                textAlign = TextAlign.Center,
+                color = contentColor
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                InfoCard(
+                    title = stringResource(R.string.market_cap),
+                    formattedText = "$ ${coin.marketCapUsd.formatted}",
+                    icon = ImageVector.vectorResource(R.drawable.stock)
+                )
+                InfoCard(
+                    title = stringResource(R.string.price),
+                    formattedText = "$ ${coin.priceUsd.formatted}",
+                    icon = ImageVector.vectorResource(R.drawable.dollar)
+                )
+                val absoluteChangeFormatted =
+                    (coin.priceUsd.value * (coin.changePercent24Hr.value / 100))
+                        .toDisplayableNumber()
+                val isPositive = coin.changePercent24Hr.value > 0.0
+                val changeColor = if (isPositive) {
+                    if(isSystemInDarkTheme()) Color.Green else greenBackground
+                } else {
+                    MaterialTheme.colorScheme.error
+                }
+                InfoCard(
+                    title = stringResource(R.string.change_last_24h),
+                    formattedText = absoluteChangeFormatted.formatted,
+                    icon = if (isPositive) {
+                        ImageVector.vectorResource(id = R.drawable.trending)
+                    } else {
+                        ImageVector.vectorResource(id = R.drawable.trending_down)
+                    },
+                    contentColor = changeColor
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun CoinDetailScreenPreview() {
+    CryptoTrackerTheme {
+        CoinDetailScreen(
+            state = CoinListState(
+                selectedCoin = previewCoin
+            ),
+            onAction = {},
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+        )
+    }
+}

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailState.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailState.kt
@@ -1,0 +1,6 @@
+package com.johnkenedy.cryptotracker.crypto.presentation.coin_detail
+
+data class CoinDetailState(
+    val paramOne: String = "default",
+    val paramTwo: List<String> = emptyList(),
+)

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailViewModel.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/CoinDetailViewModel.kt
@@ -1,0 +1,35 @@
+package com.johnkenedy.cryptotracker.crypto.presentation.coin_detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.CoinListState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+
+class CoinDetailViewModel : ViewModel() {
+
+    private var hasLoadedInitialData = false
+
+    private val _state = MutableStateFlow(CoinListState())
+    val state = _state
+        .onStart {
+            if (!hasLoadedInitialData) {
+                /** Load initial data here **/
+                hasLoadedInitialData = true
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = CoinListState()
+        )
+
+    fun onAction(action: CoinDetailAction) {
+        when (action) {
+            else -> TODO("Handle actions")
+        }
+    }
+
+}

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/components/InfoCard.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/components/InfoCard.kt
@@ -1,0 +1,119 @@
+package com.johnkenedy.cryptotracker.crypto.presentation.coin_detail.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.johnkenedy.cryptotracker.R
+import com.johnkenedy.cryptotracker.ui.theme.CryptoTrackerTheme
+
+@Composable
+fun InfoCard(
+    title: String,
+    formattedText: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface
+) {
+    val defaultTextStyle = LocalTextStyle.current.copy(
+        textAlign = TextAlign.Center,
+        fontSize = 18.sp,
+        color = contentColor
+    )
+    Card(
+        modifier = modifier
+            .padding(8.dp)
+            .shadow(
+                elevation = 15.dp,
+                shape = RectangleShape,
+                ambientColor = MaterialTheme.colorScheme.primary,
+                spotColor = MaterialTheme.colorScheme.primary
+            ),
+        shape = RectangleShape,
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.primary
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            contentColor = contentColor
+        )
+    ) {
+        AnimatedContent(
+            targetState = icon,
+            modifier = Modifier.align(
+                Alignment.CenterHorizontally
+            ),
+            label = "IconAnimation"
+        ) { icon ->
+            Icon(
+                imageVector = icon,
+                contentDescription = title,
+                modifier = Modifier
+                    .size(75.dp)
+                    .padding(top = 16.dp),
+                tint = contentColor
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        AnimatedContent(
+            targetState = formattedText,
+            modifier = Modifier.align(
+                Alignment.CenterHorizontally
+            ),
+            label = "ValueAnimation"
+        ) { formattedText ->
+            Text(
+                text = formattedText,
+                style = defaultTextStyle,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = title,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Light,
+            color = contentColor
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun InfoCardPreview() {
+    CryptoTrackerTheme {
+        InfoCard(
+            title = "Price",
+            formattedText = "$ 65,250.35",
+            icon = ImageVector.vectorResource(id = R.drawable.dollar)
+        )
+    }
+}

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListScreen.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListScreen.kt
@@ -75,7 +75,9 @@ fun CoinListScreenScreen(
             items(state.coins) { coinUi ->
                 CoinListItem(
                     coinUi = coinUi,
-                    onClick = {  },
+                    onClick = {
+                        onAction(CoinListAction.OnCoinClick(coinUi))
+                    },
                     modifier = Modifier.fillMaxWidth()
                 )
                 HorizontalDivider()

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListViewModel.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.johnkenedy.cryptotracker.core.domain.util.onError
 import com.johnkenedy.cryptotracker.core.domain.util.onSuccess
 import com.johnkenedy.cryptotracker.crypto.domain.CoinDataSource
+import com.johnkenedy.cryptotracker.crypto.presentation.models.CoinUi
 import com.johnkenedy.cryptotracker.crypto.presentation.models.toCoinUi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,13 +42,15 @@ class CoinListViewModel(
 
     fun onAction(action: CoinListAction) {
         when (action) {
-            is CoinListAction.OnCoinClick -> onCoinClick()
+            is CoinListAction.OnCoinClick -> onCoinClick(action.coinUi)
             is CoinListAction.OnRefresh -> loadCoins()
         }
     }
 
-    private fun onCoinClick() {
-        TODO("Not yet implemented")
+    private fun onCoinClick(coinUi: CoinUi) {
+        _state.update { it.copy(
+            selectedCoin = coinUi
+        ) }
     }
 
     private fun loadCoins() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
     <string name="error_no_internet">Coudn\'t connect to the server, please check your internet connection.</string>
     <string name="error_unknow">Something went wrong, please try again later.</string>
     <string name="error_serialization">Couldn\'t serialize or deserialize data.</string>
+    <string name="market_cap">Market cap</string>
+    <string name="price">Price</string>
+    <string name="change_last_24h">Change last 24h</string>
 </resources>


### PR DESCRIPTION
## 📝 Description
This commit implements the coin detail view and connects it to the coin list. Key changes include:

## 🛠️ Changes Made
- Creating `CoinDetailScreen`, `CoinDetailViewModel`, and associated state/action classes.
- Adding a reusable `InfoCard` component to display coin metrics like market cap and price.
- Updating `CoinListViewModel` to handle coin selection and update the state with the selected coin.
- Integrating click listeners in `CoinListScreen` to trigger the detail view.
- Adding string resources for market cap, price, and 24h change labels.

## 🧪 How was this tested?
- [x] Manual testing on Emulator/Device
- [ ] Unit tests added/updated
- [x] Compose Previews checked

## 📸 Screenshots / Video (Optional)


## 🔗 Related Issues
Closes #13 