### PR TITLE
Implement adaptive list-detail navigation

### DIFF
--- a/app/src/main/java/com/johnkenedy/cryptotracker/MainActivity.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/MainActivity.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.CoinListScreenRoot
+import com.johnkenedy.cryptotracker.core.navigation.AdaptiveCoinListDetailPane
 import com.johnkenedy.cryptotracker.ui.theme.CryptoTrackerTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,7 +18,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             CryptoTrackerTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    CoinListScreenRoot(
+                    AdaptiveCoinListDetailPane(
                         modifier = Modifier.padding(innerPadding)
                     )
                 }

--- a/app/src/main/java/com/johnkenedy/cryptotracker/core/navigation/AdaptiveCoinListDetailPane.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/core/navigation/AdaptiveCoinListDetailPane.kt
@@ -1,0 +1,54 @@
+@file:OptIn(ExperimentalMaterial3AdaptiveApi::class)
+
+package com.johnkenedy.cryptotracker.core.navigation
+
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneScaffold
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_detail.CoinDetailScreen
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.CoinListScreenRoot
+import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.CoinListViewModel
+import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun AdaptiveCoinListDetailPane(
+    modifier: Modifier = Modifier,
+    viewModel: CoinListViewModel = koinViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val navigator = rememberListDetailPaneScaffoldNavigator<Any>()
+    val scope = rememberCoroutineScope()
+
+    NavigableListDetailPaneScaffold(
+        navigator = navigator,
+        listPane = {
+            AnimatedPane {
+                CoinListScreenRoot(
+                    onNavigateToCoinListDetail = { coinUi ->
+                        scope.launch {
+                            navigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+                        }
+                    },
+                    viewModel = viewModel
+                )
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                CoinDetailScreen(
+                    state = state,
+                    onAction = viewModel::onAction
+                )
+            }
+        },
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/LineChart.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_detail/LineChart.kt
@@ -117,7 +117,9 @@ fun LineChart(
         val maxXLabelWidth = xLabelTextLayoutResults.maxOfOrNull { it.size.width } ?: 0
         val maxXLabelHeight = xLabelTextLayoutResults.maxOfOrNull { it.size.height } ?: 0
         val maxXLabelLineCount = xLabelTextLayoutResults.maxOfOrNull { it.lineCount } ?: 0
-        val xLabelLineHeight = maxXLabelHeight / maxXLabelLineCount
+        val xLabelLineHeight = if(maxXLabelLineCount > 0) {
+            maxXLabelHeight / maxXLabelLineCount
+        } else 0
 
         val viewPortHeightPx = size.height -
                 (maxXLabelHeight + 2 * verticalPaddingPx

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListEvent.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListEvent.kt
@@ -1,7 +1,9 @@
 package com.johnkenedy.cryptotracker.crypto.presentation.coin_list
 
 import com.johnkenedy.cryptotracker.core.domain.util.NetworkError
+import com.johnkenedy.cryptotracker.crypto.presentation.models.CoinUi
 
 sealed interface CoinListEvent {
     data class Error(val error: NetworkError): CoinListEvent
+    data class NavigateToCoinDetail(val coinUi: CoinUi): CoinListEvent
 }

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListScreen.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListScreen.kt
@@ -23,12 +23,13 @@ import com.johnkenedy.cryptotracker.core.presentation.util.ObserveAsEvent
 import com.johnkenedy.cryptotracker.core.presentation.util.toString
 import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.components.CoinListItem
 import com.johnkenedy.cryptotracker.crypto.presentation.coin_list.components.previewCoin
+import com.johnkenedy.cryptotracker.crypto.presentation.models.CoinUi
 import com.johnkenedy.cryptotracker.ui.theme.CryptoTrackerTheme
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun CoinListScreenRoot(
-    modifier: Modifier = Modifier,
+    onNavigateToCoinListDetail: (CoinUi) -> Unit,
     viewModel: CoinListViewModel = koinViewModel<CoinListViewModel>()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -43,13 +44,15 @@ fun CoinListScreenRoot(
                     Toast.LENGTH_LONG
                 ).show()
             }
+            is CoinListEvent.NavigateToCoinDetail -> {
+                onNavigateToCoinListDetail(event.coinUi)
+            }
         }
     }
 
     CoinListScreenScreen(
         state = state,
-        onAction = viewModel::onAction,
-        modifier = modifier
+        onAction = viewModel::onAction
     )
 }
 

--- a/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListViewModel.kt
+++ b/app/src/main/java/com/johnkenedy/cryptotracker/crypto/presentation/coin_list/CoinListViewModel.kt
@@ -54,6 +54,7 @@ class CoinListViewModel(
         _state.update { it.copy(selectedCoin = coinUi) }
 
         viewModelScope.launch {
+            _events.send(CoinListEvent.NavigateToCoinDetail(coinUi))
             coinDataSource
                 .getCoinHistory(
                     coinID = coinUi.id,


### PR DESCRIPTION
## 📝 Description
This change introduces an adaptive layout for the coin list and detail screens, enabling a responsive UI across different screen sizes.


## 🛠️ Changes Made
- Added `AdaptiveCoinListDetailPane` using Material 3 Adaptive API to manage the list-detail scaffold.
- Updated `MainActivity` to use the new `AdaptiveCoinListDetailPane` as the root content.
- Introduced `CoinListEvent.NavigateToCoinDetail` to handle navigation events from the `CoinListViewModel`.
- Updated `CoinListScreenRoot` to accept a navigation callback.
- Added a safety check for `maxXLabelLineCount` in `LineChart.kt` to prevent division by zero.

## 🧪 How was this tested?
- [x] Manual testing on Emulator/Device
- [ ] Unit tests added/updated
- [x ] Compose Previews checked

## 📸 Screenshots / Video (Optional)
<img width="1059" height="664" alt="Screenshot 2026-01-10 at 21 05 20" src="https://github.com/user-attachments/assets/f487592c-cf06-4569-90d7-ea1d20ecb81c" />
<img width="1057" height="663" alt="Screenshot 2026-01-10 at 21 05 31" src="https://github.com/user-attachments/assets/018a4ac1-1e97-4963-af9e-68468bdad183" />


## 🔗 Related Issues
Closes #16 